### PR TITLE
Adding support for v2 of the skytap API.

### DIFF
--- a/lib/environments.js
+++ b/lib/environments.js
@@ -12,8 +12,8 @@ var debug     = require('debug')('skytap-environments')
  * @param {Skytap} reference to parent object
  */
 function Environments(skytap) {  
-  this.getArgs = function getArgs() {
-    return skytap.getArgs();
+  this.getArgs = function getArgs(options) {
+    return skytap.getArgs(options);
   };
 }
 
@@ -31,11 +31,10 @@ module.exports = Environments;
  * @callback {Function} next
  * @return {Promise}
  */
-Environments.prototype.list = function list(next) {
-  debug('list');
+Environments.prototype.list = function list(args, next) {
+  var args = this.getArgs(args);
+  args.url = 'https://cloud.skytap.com/configurations';
 
-  var args = this.getArgs();
-  args.url = 'https://cloud.skytap.com/configurations';  
   return rest.apiGet(args, next);
 };
 

--- a/lib/environments.js
+++ b/lib/environments.js
@@ -32,6 +32,7 @@ module.exports = Environments;
  * @return {Promise}
  */
 Environments.prototype.list = function list(args, next) {
+  debug('list');
   var args = this.getArgs(args);
   args.url = 'https://cloud.skytap.com/configurations';
 

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -45,14 +45,20 @@ exports.apiDel = function(args, next) {
  * @api private
  */
 function apiRequest(args, next) {
-
   var deferred = Q.defer()    
     , opts;
+
+  if (args._v2) {
+    headers.Accept = 'application/vnd.skytap.api.v2+json';
+  } else {
+    headers.Accept = 'application/json';
+  }
 
   opts = {
     json: true,
     headers: headers,    
   };
+
   opts = arghelper.combine(opts, args);
   opts = arghelper.convertAuth(opts);
   opts = arghelper.convertUrlParams(opts);

--- a/lib/skytap.js
+++ b/lib/skytap.js
@@ -26,8 +26,10 @@ function Skytap () {
   this.vms          = new Vms(this);
   this.vpns         = new Vpns(this);
 
-  this.getArgs = function getArgs() {
-    return _.clone(this._config);
+  this.getArgs = function getArgs(options) {
+	var options = options || {};
+    _.defaults(options, this._config);
+	return options;
   };
 }
 


### PR DESCRIPTION
Skytap is partially exposing their v2 API for certain calls. One call in particular is the list environments endpoint. Using the v2 endpoint gives you much more information ( including runstate ). This saves me from having to do 1 query to list the environments, and N calls to fetch individual environment states.

To invoke the v2 API, you have to change the Accept header to: application/vnd.skytap.api.v2+json

In order to make this easily portable, I modified the param processor and the api request function. This now allows any api method to be expanded using { _v2: true }. 

I only modified the list environments end point, but will modify more as I come across them. This change is completely backwards compatible.

The new way of calling this is:
skytap.environments.list({_v2: true}).then(function(res) {
    console.log(res);
});


