### PR TITLE
Allow `list` fn parameters

### DIFF
--- a/lib/environments.js
+++ b/lib/environments.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-environments')
   , Q         = require('q')
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 
@@ -32,13 +33,14 @@ module.exports = Environments;
  * @callback {Function} next
  * @return {Promise}
  */
-Environments.prototype.list = function list(next) {
+Environments.prototype.list = vargs(function list(params, next) {
   debug('list');
 
-  var args = this.getArgs();  
-  args.url = 'https://cloud.skytap.com/configurations';    
+  var args = this.getArgs();
+  args.url = 'https://cloud.skytap.com/configurations';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 /**

--- a/lib/ips.js
+++ b/lib/ips.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-ips')
   , Q         = require('q')  
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 
@@ -31,13 +32,14 @@ module.exports = Ips;
  * @callback {Function} next
  * @return {Promise}
  */
-Ips.prototype.list = function list(next) {
+Ips.prototype.list = vargs(function list(params, next) {
   debug('publicips %j', args);
 
   var args = this.getArgs();
   args.url = 'https://cloud.skytap.com/ips';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 // TODO

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-projects')
   , Q         = require('q')  
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 /** 
@@ -30,13 +31,14 @@ module.exports = Projects;
  * @callback {Function} next
  * @return {Promise}
  */
-Projects.prototype.list = function list(next) {
+Projects.prototype.list = vargs(function list(params, next) {
   debug('list');
 
   var args = this.getArgs();
   args.url = 'https://cloud.skytap.com/projects';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 /**

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-templates')
   , Q         = require('q')
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 
@@ -32,13 +33,14 @@ module.exports = Templates;
  * @callback {Function} next
  * @return {Promise}
  */
-Templates.prototype.list = function list(next) {
+Templates.prototype.list = vargs(function list(params, next) {
   debug('list');
 
   var args = this.getArgs();
-  args.url = 'https://cloud.skytap.com/templates';  
+  args.url = 'https://cloud.skytap.com/templates';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 /**

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-users')
   , Q         = require('q')  
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 /** 
@@ -30,13 +31,14 @@ module.exports = Users;
  * @callback {Function} next
  * @return {Promise}
  */
-Users.prototype.list = function list(next) {
+Users.prototype.list = vargs(function list(params, next) {
   debug('list');
 
   var args = this.getArgs();
-  args.url = 'https://cloud.skytap.com/users';  
+  args.url = 'https://cloud.skytap.com/users';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 /**

--- a/lib/vpns.js
+++ b/lib/vpns.js
@@ -1,7 +1,8 @@
 var debug     = require('debug')('skytap-vpns')
   , Q         = require('q')  
   , arghelper = require('./arghelper')
-  , rest      = require('./rest');
+  , rest      = require('./rest')
+  , vargs     = require('vargs-callback');
 
 
 
@@ -32,13 +33,14 @@ module.exports = VPNs;
  * @callback {Function} next
  * @return {Promise}
  */
-VPNs.prototype.list = function list(next) {
+VPNs.prototype.list = vargs(function list(params, next) {
   debug('list');
 
   var args = this.getArgs();
   args.url = 'https://cloud.skytap.com/vpns';
+  args.params = params;
   return rest.apiGet(args, next);
-};
+});
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "debug": "^2.1.1",
     "q": "^1.0.1",
     "request": "^2.51.0",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "vargs-callback": "^0.2.4"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/environments.js
+++ b/test/environments.js
@@ -14,6 +14,15 @@ describe('Skytap.environments', function () {
         return _.bind(skytap.environments.list, skytap.environments);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/configurations?foo=bar').reply(200);
+        return _.bind(skytap.environments.list, skytap.environments, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.get', function () {

--- a/test/ips.js
+++ b/test/ips.js
@@ -14,6 +14,15 @@ describe('Skytap.ips', function () {
         return _.bind(skytap.ips.list, skytap.ips);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/ips?foo=bar').reply(200);
+        return _.bind(skytap.ips.list, skytap.ips, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.attach', function () {

--- a/test/projects.js
+++ b/test/projects.js
@@ -14,6 +14,15 @@ describe('Skytap.projects', function () {
         return _.bind(skytap.projects.list, skytap.projects);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/projects?foo=bar').reply(200);
+        return _.bind(skytap.projects.list, skytap.projects, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.get', function () {

--- a/test/templates.js
+++ b/test/templates.js
@@ -14,6 +14,15 @@ describe('Skytap.templates', function () {
         return _.bind(skytap.templates.list, skytap.templates);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/templates?foo=bar').reply(200);
+        return _.bind(skytap.templates.list, skytap.templates, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.get', function () {

--- a/test/users.js
+++ b/test/users.js
@@ -14,6 +14,15 @@ describe('Skytap.users', function () {
         return _.bind(skytap.users.list, skytap.users);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/users?foo=bar').reply(200);
+        return _.bind(skytap.users.list, skytap.users, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.get', function () {

--- a/test/vpns.js
+++ b/test/vpns.js
@@ -14,6 +14,15 @@ describe('Skytap.vpns', function () {
         return _.bind(skytap.vpns.list, skytap.vpns);
       });
     });
+
+    it('takes optional parameters', function () {
+      return nockspect(function (nock) {
+        nock.get('/vpns?foo=bar').reply(200);
+        return _.bind(skytap.vpns.list, skytap.vpns, {
+          foo: 'bar'
+        });
+      });
+    });
   });
 
   describe('.get', function () {


### PR DESCRIPTION
I've used the [vargs-callback](https://github.com/furagu/vargs-callback) library in lieu of manually checking the args.

Manual would look something like:

```
environments.list(params, next) {

  if (_.isFunction(params)) {
    next = params
  } else {
    args.params = params
  }
}
```

I've done some basic tests in the MockTests branch of my fork, and it appears to work with callbacks, promises, and generators.

We may want to hold-off on merging this until more detailed api testing is implemented...