### PR TITLE
Fix lone `?` from being added to the end of a query string if empty params passed

### DIFF
--- a/lib/arghelper.js
+++ b/lib/arghelper.js
@@ -79,7 +79,8 @@ exports.convertAuth = function convertAuth(opts) {
 exports.convertReqParams = function convertReqParams(opts) {
     var result = opts
       , method = result.method
-      , params = result.params;
+      , params = result.params
+      , queryString;
 
   if(params) {
 
@@ -87,12 +88,15 @@ exports.convertReqParams = function convertReqParams(opts) {
     result = _.clone(opts);
 
     // handle GET requests by appending to the query string
-    if(method === 'GET') {          
-      if(result.url.indexOf('?') === -1) {
-        result.url = result.url + '?' + qs.stringify(params);
-      }
-      else {
-        result.url = result.url + '&' + qs.stringify(params);
+    if(method === 'GET') {
+      queryString = qs.stringify(params);
+      if (queryString.length) {
+        if(result.url.indexOf('?') === -1) {
+          result.url = result.url + '?' + queryString;
+        }
+        else {
+          result.url = result.url + '&' + queryString;
+        }
       }
     }
 

--- a/test/arghelper.js
+++ b/test/arghelper.js
@@ -266,6 +266,16 @@ describe('arghelper', function() {
       expect(result.url).to.equal('http://localhost');
     });
 
+    it('should handle empty params on GET request', function () {
+      var opts = {
+        url: 'http://localhost',
+        method: 'GET',
+        params: {}
+      };
+      var result = helpers.convertReqParams(opts);
+      // Make sure doesn't append `?` followed by empty string
+      expect(result.url).to.equal('http://localhost');
+    });
 
     it('should handle no params on POST/PUT/DELETE request', function () {
       var opts = {


### PR DESCRIPTION
If empty params object is passed to `convertReqParams`, a lone `?` is appended to the end of the query string.

Old code fails new test:

```
1 failing

  1) arghelper #convertReqParams should handle empty params on GET request:

      AssertionError: expected 'http://localhost?' to equal 'http://localhost'
      + expected - actual

      +http://localhost
      -http://localhost?
```