### PR TITLE
Update travis.yml to test node-latest, node LTS 4.2.x, and node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "iojs"
+  - "4.2"
+  - "0.12"
 before_install: npm install -g grunt-cli


### PR DESCRIPTION
Node.js Foundation has released Node v4. The LTS release is now 4.2.x (Argon). io.js is deprecated. Updating travis to test 0.12, LTS Argon, and node latest.